### PR TITLE
Add HTTPS to client-server connection

### DIFF
--- a/client/src/contexts/connection.jsx
+++ b/client/src/contexts/connection.jsx
@@ -16,7 +16,7 @@ export const ConnectionProvider = ({ children }) => {
     if (accessToken) {
       const newWs = new WebSocket(
         //'ws://localhost:8080/' + 'token=' + accessToken,
-        'ws://cardz-against-humanity.herokuapp.com/' + 'token=' + accessToken,
+        'wss://cardz-against-humanity.herokuapp.com/' + 'token=' + accessToken,
       );
       setWs(newWs);
     }

--- a/client/src/utils/resources/index.jsx
+++ b/client/src/utils/resources/index.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 //const url = 'http://localhost:8080/';
-const url = 'http://cardz-against-humanity.herokuapp.com/';
+const url = 'https://cardz-against-humanity.herokuapp.com/';
 
 export const login = ({ username, password }) =>
   axios.post(`${url}user/login`, {


### PR DESCRIPTION
As the server on heroku uses ssl, we can connect to it with https and wss. It's necessary for hosting the client, because otherwise the browser complains if the user <-> client connection uses https and at the same time client <-> server connection is not encrypted.